### PR TITLE
Fix obsolete deno import since Deno v0.3.3

### DIFF
--- a/opn.ts
+++ b/opn.ts
@@ -1,4 +1,4 @@
-import { run, platform } from "deno";
+const { run, platform } = Deno;
 
 //WSL is not supported
 //because "platform" in WSL returns just `{ arch: "x64", os: "linux" }`


### PR DESCRIPTION
There has been a breaking API change in Deno v.0.3.3 that also breaks this module. The import of "deno" module got replaced with a global Deno variable.

The "deno" module removal PR: https://github.com/denoland/deno/pull/1895
Release notes of v.0.3.3: https://github.com/denoland/deno/commit/3dbb06e699398549e8cfabc896ef3256ab433cba#diff-30ebd105aef11de730b7b473a247e99bR16

**Please make sure to release this fix in a major new version (v1.1.0) as the fix itself is a breaking change for people running deno@0.3.2 or older.**